### PR TITLE
Reduce allocation size when emitting yaml

### DIFF
--- a/pkg/yamlmeta/internal/yaml.v2/emitterc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/emitterc.go
@@ -127,6 +127,13 @@ func yamlEmitterEmit(emitter *yamlEmitterT, event *yamlEventT) bool {
 		yamlEventDelete(event)
 		emitter.eventsHead++
 	}
+
+	// if eventsHead is caught up, then reset events back to empty to reduce allocations
+	if emitter.eventsHead > 0 && emitter.eventsHead == len(emitter.events) {
+		emitter.events = emitter.events[:0]
+		emitter.eventsHead = 0
+	}
+
 	return true
 }
 

--- a/pkg/yamlmeta/internal/yaml.v2/emitterc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/emitterc.go
@@ -140,10 +140,9 @@ func yamlEmitterEmit(emitter *yamlEmitterT, event *yamlEventT) bool {
 // Check if we need to accumulate more events before emitting.
 //
 // We accumulate extra
-//  - 1 event for DOCUMENT-START
-//  - 2 events for SEQUENCE-START
-//  - 3 events for MAPPING-START
-//
+//   - 1 event for DOCUMENT-START
+//   - 2 events for SEQUENCE-START
+//   - 3 events for MAPPING-START
 func yamlEmitterNeedMoreEvents(emitter *yamlEmitterT) bool {
 	if emitter.eventsHead == len(emitter.events) {
 		return true

--- a/pkg/yamlmeta/internal/yaml.v2/emitterc_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/emitterc_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TestEmitterEventQueueIsRewound checks that yamlEmitterEmit resets eventsHead
+// back to zero once the event queue drains. That keeps the queue's backing
+// array bounded by nesting depth instead of growing one entry per node.
+func TestEmitterEventQueueIsRewound(t *testing.T) {
+	const keys = 2000
+
+	doc := make(map[string]any, keys)
+	for i := range keys {
+		doc[fmt.Sprintf("key%05d", i)] = i
+	}
+
+	e := newEncoder()
+	defer e.destroy()
+
+	e.marshalDoc("", reflect.ValueOf(doc))
+
+	if e.emitter.eventsHead != 0 {
+		t.Errorf("eventsHead = %d, want 0", e.emitter.eventsHead)
+	}
+	// Without the rewind this grows to roughly 2*keys.
+	if c := cap(e.emitter.events); c > 32 {
+		t.Errorf("cap(emitter.events) = %d after emitting %d keys, want <= 32", c, keys)
+	}
+}


### PR DESCRIPTION
Reset the `events` slice back to empty when `eventsHead` is fully caught up. Currently the `events` slice expands forever, causing large allocations.

This is a change to the internal version of the yaml.v2 package (which has additional modifications compared to upstream). I also intend to upstream this to https://github.com/yaml/go-yaml at a later date. Surprised no one has noticed yet 😁 

<details>
<summary>Benchmark Code</summary>

(I just stuffed it into `pkg/yamlmeta/internal/yaml.v2/encode_test.go` temporarily while testing

```golang
func BenchmarkMarshalReleaseWorkflow(b *testing.B) {
	data, err := os.ReadFile("../../../../.github/workflows/release.yml")
	if err != nil {
		b.Fatalf("failed to read release.yml: %v", err)
	}
	var v any
	err = yaml.Unmarshal(data, &v)
	if err != nil {
		b.Fatalf("failed to unmarshal release.yml: %v", err)
	}

	b.ReportAllocs()

	for b.Loop() {
		_, err := yaml.Marshal(v)
		if err != nil {
			b.Fatalf("marshal failed: %v", err)
		}
	}
}
```

</details>

Benchmark details:
```
$ benchstat before.bench after.bench 
goos: linux
goarch: amd64
pkg: carvel.dev/ytt/pkg/yamlmeta/internal/yaml.v2
cpu: INTEL(R) XEON(R) PLATINUM 8580
                         │ before.bench │             after.bench             │
                         │    sec/op    │   sec/op     vs base                │
MarshalReleaseWorkflow-4   170.0µ ± 13%   134.0µ ± 9%  -21.20% (p=0.000 n=10)

                         │ before.bench  │             after.bench              │
                         │     B/op      │     B/op      vs base                │
MarshalReleaseWorkflow-4   120.55Ki ± 0%   30.53Ki ± 0%  -74.67% (p=0.000 n=10)

                         │ before.bench │            after.bench            │
                         │  allocs/op   │ allocs/op   vs base               │
MarshalReleaseWorkflow-4     397.0 ± 0%   393.0 ± 0%  -1.01% (p=0.000 n=10)
```