### PR TITLE
Avoid computing debug template dump when debug is off

### DIFF
--- a/pkg/cmd/ui/tty.go
+++ b/pkg/cmd/ui/tty.go
@@ -35,6 +35,12 @@ func (t TTY) Debugf(str string, args ...interface{}) {
 	}
 }
 
+// IsDebug reports whether debug output is enabled. Callers can use it to
+// skip computing expensive Debugf arguments when debugging is off.
+func (t TTY) IsDebug() bool {
+	return t.debug
+}
+
 func (t TTY) DebugWriter() io.Writer {
 	if t.debug {
 		return os.Stderr

--- a/pkg/cmd/ui/tty_test.go
+++ b/pkg/cmd/ui/tty_test.go
@@ -1,0 +1,17 @@
+// Copyright 2026 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"carvel.dev/ytt/pkg/cmd/ui"
+)
+
+func TestIsDebugReportsDebugMode(t *testing.T) {
+	require.True(t, ui.NewTTY(true).IsDebug())
+	require.False(t, ui.NewTTY(false).IsDebug())
+}

--- a/pkg/cmd/ui/ui.go
+++ b/pkg/cmd/ui/ui.go
@@ -12,4 +12,5 @@ type UI interface {
 	Debugf(string, ...interface{})
 	Warnf(str string, args ...interface{})
 	DebugWriter() io.Writer
+	IsDebug() bool
 }

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -196,7 +196,9 @@ func (l *TemplateLoader) EvalYAML(libraryCtx LibraryExecutionContext, file *file
 	}
 
 	l.addCompiledTemplate(file.RelativePath(), compiledTemplate)
-	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	if l.ui.IsDebug() {
+		l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	}
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
 		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),
@@ -238,7 +240,9 @@ func (l *TemplateLoader) EvalText(libraryCtx LibraryExecutionContext, file *file
 	}
 
 	l.addCompiledTemplate(file.RelativePath(), compiledTemplate)
-	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	if l.ui.IsDebug() {
+		l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	}
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
 		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),
@@ -268,7 +272,9 @@ func (l *TemplateLoader) EvalStarlark(libraryCtx LibraryExecutionContext, file *
 		instructions, template.NewNodes(), template.EvaluationCtxDialects{})
 
 	l.addCompiledTemplate(file.RelativePath(), compiledTemplate)
-	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	if l.ui.IsDebug() {
+		l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
+	}
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
 		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),


### PR DESCRIPTION
## What this PR does / why we need it

`TemplateLoader` calls `l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())` after compiling every YAML, text, and Starlark template. Since Go evaluates function arguments eagerly, `DebugCodeAsString()` — which serializes every compiled code line via `fmt.Sprintf` and joins them into one large string — runs on every template evaluation, even though `Debugf` immediately discards the result unless `--debug` is set.

This PR adds an `IsDebug()` method to the `ui.UI` interface and guards the three call sites so the debug dump is only computed when debug output is actually enabled. Benchmarking shows a measurable performance improvement on template-heavy workloads, and it also removes the associated allocation/GC pressure.

## Which issue(s) this PR fixes

None filed; found while benchmarking template evaluation.

## Describe testing done for PR

- Added a unit test for `TTY.IsDebug()` (`pkg/cmd/ui/tty_test.go`)
- `go build ./...` and `go test ./pkg/...` pass
- Verified `--debug` output is unchanged

## Does this PR introduce a user-facing change?

```release-note
Improved template evaluation performance by skipping debug string generation when --debug is not set
```

## Additional Notes for your reviewer

`TTY` is the only implementation of `ui.UI` in the codebase, so extending the interface is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)