### PR TITLE
Deprecate @ytt:md5 module in favor of @ytt:sha256

### DIFF
--- a/pkg/yttlibrary/all.go
+++ b/pkg/yttlibrary/all.go
@@ -49,7 +49,7 @@ func NewAPI(
 		"regexp": RegexpAPI,
 
 		// Hashes
-		"md5":    MD5API,
+		"md5":    NewMD5Module(ui).AsModule(),
 		"sha256": SHA256API,
 
 		// Serializations

--- a/pkg/yttlibrary/md5.go
+++ b/pkg/yttlibrary/md5.go
@@ -6,26 +6,74 @@ package yttlibrary
 import (
 	"crypto/md5"
 	"fmt"
+	"sync/atomic"
 
+	"carvel.dev/ytt/pkg/cmd/ui"
 	"carvel.dev/ytt/pkg/template/core"
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/starlark-go/starlarkstruct"
 )
 
-var (
-	MD5API = starlark.StringDict{
+// MD5Module contains the definition of the @ytt:md5 module.
+//
+// Deprecated: MD5 is a cryptographically broken hash algorithm. This
+// module is retained only for backward compatibility with existing
+// templates; use the @ytt:sha256 module instead.
+type MD5Module struct {
+	ui ui.UI
+}
+
+// hasWarnedMD5Deprecated indicates whether the deprecation notice for
+// this module has been displayed. This flag ensures we display that
+// warning only once; more than once and its noise. It's an atomic.Bool
+// since Starlark builtins may be invoked concurrently across goroutines
+// when ytt is embedded as a library.
+var hasWarnedMD5Deprecated atomic.Bool
+
+// NewMD5Module constructs a new instance of MD5Module with the
+// configured UI (to enable displaying a warning).
+func NewMD5Module(uiArg ui.UI) MD5Module {
+	return MD5Module{ui: uiArg}
+}
+
+// AsModule produces the corresponding Starlark module definition
+// suitable for use in running a Starlark program.
+func (b MD5Module) AsModule() starlark.StringDict {
+	sumFunc := core.ErrWrapper(b.warnOnCall(b.sum))
+	return starlark.StringDict{
 		"md5": &starlarkstruct.Module{
 			Name: "md5",
 			Members: starlark.StringDict{
-				"sum": starlark.NewBuiltin("md5.sum", core.ErrWrapper(md5Module{}.Sum)),
+				"sum": starlark.NewBuiltin("md5.sum", sumFunc),
 			},
 		},
 	}
-)
+}
 
-type md5Module struct{}
+// warnOnCall ensures that if the wrapped function is called, the
+// user is warned that md5 is deprecated.
+func (b MD5Module) warnOnCall(wrappedFunc core.StarlarkFunc) core.StarlarkFunc {
+	return func(
+		thread *starlark.Thread,
+		f *starlark.Builtin,
+		args starlark.Tuple,
+		kwargs []starlark.Tuple,
+	) (starlark.Value, error) {
+		if hasWarnedMD5Deprecated.CompareAndSwap(false, true) {
+			b.ui.Warnf("\nWarning: @ytt:md5 module is deprecated " +
+				"because MD5 is a cryptographically weak hash " +
+				"algorithm; use @ytt:sha256 instead.\n")
+		}
+		return wrappedFunc(thread, f, args, kwargs)
+	}
+}
 
-func (b md5Module) Sum(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (MD5Module) sum(
+	_ *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	_ []starlark.Tuple,
+) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}

--- a/pkg/yttlibrary/md5_test.go
+++ b/pkg/yttlibrary/md5_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package yttlibrary
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"carvel.dev/ytt/pkg/cmd/ui"
+	"github.com/k14s/starlark-go/starlark"
+)
+
+func TestMD5SumEmitsDeprecationWarningOnce(t *testing.T) {
+	hasWarnedMD5Deprecated.Store(false)
+	defer hasWarnedMD5Deprecated.Store(false)
+
+	var stderr bytes.Buffer
+	mod := NewMD5Module(ui.NewCustomWriterTTY(false, nil, &stderr))
+	sumFunc := mod.warnOnCall(mod.sum)
+	args := starlark.Tuple{starlark.String("data")}
+
+	result, err := sumFunc(nil, nil, args, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSum := starlark.String("8d777f385d3dfec8815d20f7496026dc")
+	if result != expectedSum {
+		t.Errorf("expected sum %q, got %q", expectedSum, result)
+	}
+
+	if !strings.Contains(stderr.String(), "@ytt:md5 module is deprecated") {
+		t.Errorf("expected deprecation warning on stderr, got: %q",
+			stderr.String())
+	}
+
+	// A second call must not repeat the warning.
+	stderr.Reset()
+	if _, err := sumFunc(nil, nil, args, nil); err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no warning on second call, got: %q", stderr.String())
+	}
+}

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"carvel.dev/ytt/pkg/cmd/ui"
 	"carvel.dev/ytt/pkg/template"
 	"carvel.dev/ytt/pkg/template/core"
 	"carvel.dev/ytt/pkg/version"
@@ -256,7 +257,7 @@ func (l DefaultTemplateLoader) Load(_ *starlark.Thread, module string) (starlark
 		yttlibrary.NewDataModule(
 			core.NewGoValueWithOpts(l.DataValues.AsInterface(),
 				core.GoValueOpts{MapIsStruct: true},
-			).AsStarlarkValue(), nil), nil, nil)
+			).AsStarlarkValue(), nil), nil, ui.NewTTY(false))
 	return api.FindModule(strings.TrimPrefix(module, "@ytt:"))
 }
 


### PR DESCRIPTION
## Summary
- Deprecates the `@ytt:md5` module's `sum()` builtin in favor of `@ytt:sha256.sum()`, which already exists in this codebase.
- `md5.sum()` behavior and output are unchanged (byte-for-byte), so existing templates keep working exactly as before — this is not a breaking change.
- Adds a one-time deprecation warning (printed to stderr via `ui.Warnf`), mirroring the existing convention used by the `@ytt:math` module for its own caveat warning.
- Fixes a latent bug in `test/filetests/filetests.go`: the test harness constructed `yttlibrary.NewAPI(...)` with a literal `nil` for the `ui.UI` parameter. This went unnoticed because no existing `.tpltest` fixture exercised a `ui`-dependent module (like `@ytt:math`) — but `md5.tpltest` does exercise `@ytt:md5`, so adding the warning immediately surfaced a nil-pointer panic. Fixed by passing a real `ui.NewTTY(false)`.

## Why
MD5 is a cryptographically broken hash algorithm. `sha256.sum()` is a safer, already-available alternative. Since `md5.sum()` is a public Starlark API that existing templates may depend on for non-security purposes (e.g. deterministic identifiers), removing it outright would be a breaking change — so this follows the same soft-deprecation pattern already established for `@ytt:math`: keep the function working, warn once per process, and point users to the recommended replacement.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Full unit test suite passes (`go test ./...`), including the existing `pkg/yamltemplate/filetests/ytt-library/md5.tpltest` fixture, which now also exercises the new warning code path (previously would have nil-pointer-panicked without the `filetests.go` fix)
```
go test ./pkg/yamltemplate/... -run 'TestYAMLTemplate/filetests/ytt-library/md5.tpltest' -v 2>&1


=== RUN   TestYAMLTemplate
=== RUN   TestYAMLTemplate/filetests/ytt-library/md5.tpltest

Warning: @ytt:md5 module is deprecated because MD5 is a cryptographically weak hash algorithm; use @ytt:sha256 instead.
--- PASS: TestYAMLTemplate (0.01s)
    --- PASS: TestYAMLTemplate/filetests/ytt-library/md5.tpltest (0.00s)
PASS
ok      carvel.dev/ytt/pkg/yamltemplate (cached)
```
- [x] Manually verified via `./ytt -f -` that:
  - stdout only contains the rendered template result (unchanged)
  - stderr contains the one-time deprecation warning
