### PR TITLE
Include filenames in Starlark errors

### DIFF
--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -312,6 +312,26 @@ simple_key: #@ another_data()
 	require.EqualError(t, out.Err, expectedErr)
 }
 
+func TestStarlarkErrorIncludesFilename(t *testing.T) {
+	starlarkData := []byte(`def testfunc():
+  wrong
+end`)
+
+	expectedErr := "Evaluating starlark template: \n" +
+		"- undefined: wrong\n" +
+		"    funcs.star:2 |   wrong"
+
+	filesToProcess := []*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("funcs.star", starlarkData)),
+	}
+
+	ui := ui.NewTTY(false)
+	opts := cmdtpl.NewOptions()
+
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	require.EqualError(t, out.Err, expectedErr)
+}
+
 func TestDisallowDirectLibraryLoading(t *testing.T) {
 	yamlTplData := []byte(`#@ load("_ytt_lib/data.lib.star", "data")`)
 

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -322,13 +322,15 @@ end`)
 		"    funcs.star:2 |   wrong"
 
 	filesToProcess := []*files.File{
-		files.MustNewFileFromSource(files.NewBytesSource("funcs.star", starlarkData)),
+		files.MustNewFileFromSource(
+			files.NewBytesSource("funcs.star", starlarkData),
+		),
 	}
 
-	ui := ui.NewTTY(false)
+	testUI := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, testUI)
 	require.EqualError(t, out.Err, expectedErr)
 }
 

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -266,7 +266,9 @@ func (l *TemplateLoader) EvalStarlark(libraryCtx LibraryExecutionContext, file *
 	instructions := template.NewInstructionSet()
 	compiledTemplate := template.NewCompiledTemplate(
 		file.RelativePath(), template.NewCodeFromBytesAtPosition(
-			fileBs, filepos.NewPositionInFile(1, file.RelativePath()), instructions),
+			fileBs,
+			filepos.NewPositionInFile(1, file.RelativePath()),
+			instructions),
 		instructions, template.NewNodes(), template.EvaluationCtxDialects{})
 
 	l.addCompiledTemplate(file.RelativePath(), compiledTemplate)

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"carvel.dev/ytt/pkg/cmd/ui"
+	"carvel.dev/ytt/pkg/filepos"
 	"carvel.dev/ytt/pkg/files"
 	"carvel.dev/ytt/pkg/template"
 	"carvel.dev/ytt/pkg/template/core"
@@ -264,7 +265,8 @@ func (l *TemplateLoader) EvalStarlark(libraryCtx LibraryExecutionContext, file *
 
 	instructions := template.NewInstructionSet()
 	compiledTemplate := template.NewCompiledTemplate(
-		file.RelativePath(), template.NewCodeFromBytes(fileBs, instructions),
+		file.RelativePath(), template.NewCodeFromBytesAtPosition(
+			fileBs, filepos.NewPositionInFile(1, file.RelativePath()), instructions),
 		instructions, template.NewNodes(), template.EvaluationCtxDialects{})
 
 	l.addCompiledTemplate(file.RelativePath(), compiledTemplate)


### PR DESCRIPTION
## Summary

Include the relative source filename in errors from standalone Starlark files so their diagnostics match the existing behavior for YAML template files.

Add a focused regression test for the direct `.star` evaluation error from #633.

Fixes #633

## Testing

- `go test ./pkg/cmd/template -run '^(TestLoad|TestBacktraceAcrossFiles|TestStarlarkErrorIncludesFilename|TestDisallowDirectLibraryLoading|TestRelativeLoadInLibraries|TestRelativeLoadInLibrariesForNonRootTemplates)$' -count=1`
- `go test ./pkg/template ./pkg/workspace -count=1`
- `hack/test-windows.ps1`
