### PR TITLE
Skip leading UTF-8 BOMs in YAML, Starlark, and text templates

### DIFF
--- a/pkg/cmd/template/utf8_bom_test.go
+++ b/pkg/cmd/template/utf8_bom_test.go
@@ -64,10 +64,12 @@ func TestUTF8BOMStarlarkLibraryLoadsTheSameAsNoBOM(t *testing.T) {
 	renderWithLibrary := func(t *testing.T, libraryData []byte) string {
 		t.Helper()
 
+		dataYML := "#@ load(\"values.star\", \"value\")\nresult: #@ value\n"
 		filesToProcess := []*files.File{
-			files.MustNewFileFromSource(files.NewBytesSource(
-				"data.yml", []byte("#@ load(\"values.star\", \"value\")\nresult: #@ value\n"))),
-			files.MustNewFileFromSource(files.NewBytesSource("values.star", libraryData)),
+			files.MustNewFileFromSource(
+				files.NewBytesSource("data.yml", []byte(dataYML))),
+			files.MustNewFileFromSource(
+				files.NewBytesSource("values.star", libraryData)),
 		}
 
 		out := cmdtpl.NewOptions().RunWithFiles(

--- a/pkg/cmd/template/utf8_bom_test.go
+++ b/pkg/cmd/template/utf8_bom_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"testing"
+
+	cmdtpl "carvel.dev/ytt/pkg/cmd/template"
+	"carvel.dev/ytt/pkg/cmd/ui"
+	"carvel.dev/ytt/pkg/files"
+	"github.com/stretchr/testify/require"
+)
+
+const utf8BOM = "\xEF\xBB\xBF"
+
+// A file saved with a UTF-8 BOM should render exactly like the same file
+// without one. Before this was handled the BOM was read as part of the first
+// key, so `test: #@ None` rendered as a quoted, escaped key instead of `test`.
+func TestUTF8BOMRendersTheSameAsNoBOM(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "annotated value",
+			template: "test: #@ None\n",
+			expected: "test: null\n",
+		},
+		{
+			name:     "explicit document marker",
+			template: "---\ntest: 1\n",
+			expected: "test: 1\n",
+		},
+		{
+			name:     "ytt comment first",
+			template: "#! a comment\ntest: 1\n",
+			expected: "test: 1\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withoutBOM := renderOneFile(t, []byte(tc.template))
+			require.Equal(t, tc.expected, withoutBOM,
+				"the control case rendered unexpectedly")
+
+			withBOM := renderOneFile(t, []byte(utf8BOM+tc.template))
+			require.Equal(t, withoutBOM, withBOM,
+				"a leading UTF-8 BOM changed the output")
+		})
+	}
+}
+
+// Only a leading BOM is a stream marker. One part way through a file is
+// ordinary content, and the emitter keeps it by quoting and escaping it.
+func TestUTF8BOMInsideAFileIsLeftAlone(t *testing.T) {
+	rendered := renderOneFile(t, []byte("test: \"a"+utf8BOM+"b\"\n"))
+	require.Equal(t, "test: \"a\\uFEFFb\"\n", rendered)
+}
+
+func renderOneFile(t *testing.T, data []byte) string {
+	t.Helper()
+
+	filesToProcess := []*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("data.yml", data)),
+	}
+
+	input := cmdtpl.Input{Files: filesToProcess}
+	out := cmdtpl.NewOptions().RunWithFiles(input, ui.NewTTY(false))
+	require.NoError(t, out.Err)
+	require.Len(t, out.Files, 1, "unexpected number of output files")
+
+	return string(out.Files[0].Bytes())
+}

--- a/pkg/cmd/template/utf8_bom_test.go
+++ b/pkg/cmd/template/utf8_bom_test.go
@@ -60,11 +60,55 @@ func TestUTF8BOMInsideAFileIsLeftAlone(t *testing.T) {
 	require.Equal(t, "test: \"a\\uFEFFb\"\n", rendered)
 }
 
+func TestUTF8BOMStarlarkLibraryLoadsTheSameAsNoBOM(t *testing.T) {
+	renderWithLibrary := func(t *testing.T, libraryData []byte) string {
+		t.Helper()
+
+		filesToProcess := []*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource(
+				"data.yml", []byte("#@ load(\"values.star\", \"value\")\nresult: #@ value\n"))),
+			files.MustNewFileFromSource(files.NewBytesSource("values.star", libraryData)),
+		}
+
+		out := cmdtpl.NewOptions().RunWithFiles(
+			cmdtpl.Input{Files: filesToProcess}, ui.NewTTY(false))
+		require.NoError(t, out.Err)
+		require.Len(t, out.Files, 1, "unexpected number of output files")
+
+		return string(out.Files[0].Bytes())
+	}
+
+	const library = "value = \"from starlark\"\n"
+	withoutBOM := renderWithLibrary(t, []byte(library))
+	require.Equal(t, "result: from starlark\n", withoutBOM,
+		"the control case rendered unexpectedly")
+
+	withBOM := renderWithLibrary(t, []byte(utf8BOM+library))
+	require.Equal(t, withoutBOM, withBOM,
+		"a leading UTF-8 BOM changed how a Starlark library loaded")
+}
+
+func TestUTF8BOMTextTemplateRendersTheSameAsNoBOM(t *testing.T) {
+	const textTemplate = "result: (@= \"from text template\" @)\n"
+
+	withoutBOM := renderOneNamedFile(t, "data.txt", []byte(textTemplate))
+	require.Equal(t, "result: from text template\n", withoutBOM,
+		"the control case rendered unexpectedly")
+
+	withBOM := renderOneNamedFile(t, "data.txt", []byte(utf8BOM+textTemplate))
+	require.Equal(t, withoutBOM, withBOM,
+		"a leading UTF-8 BOM changed the text-template output")
+}
+
 func renderOneFile(t *testing.T, data []byte) string {
+	return renderOneNamedFile(t, "data.yml", data)
+}
+
+func renderOneNamedFile(t *testing.T, name string, data []byte) string {
 	t.Helper()
 
 	filesToProcess := []*files.File{
-		files.MustNewFileFromSource(files.NewBytesSource("data.yml", data)),
+		files.MustNewFileFromSource(files.NewBytesSource(name, data)),
 	}
 
 	input := cmdtpl.Input{Files: filesToProcess}

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -4,12 +4,23 @@
 package files
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 )
+
+// utf8BOM is the UTF-8 encoding of U+FEFF. Some editors, and Windows tooling in
+// particular, write it at the start of a file to record the encoding.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// TrimUTF8BOM returns data without a leading UTF-8 byte order mark. It only
+// removes the stream marker; a U+FEFF later in the input remains content.
+func TrimUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
 
 var (
 	yamlExts     = []string{".yaml", ".yml"}

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -227,6 +227,8 @@ func (l *TemplateLoader) EvalText(libraryCtx LibraryExecutionContext, file *file
 		return nil, plainRootNode, nil
 	}
 
+	fileBs = files.TrimUTF8BOM(fileBs)
+
 	textRoot, err := texttemplate.NewParser().Parse(fileBs, file.RelativePath())
 	if err != nil {
 		return nil, nil, fmt.Errorf("Parsing text template '%s': %s", file.RelativePath(), err)
@@ -261,6 +263,8 @@ func (l *TemplateLoader) EvalStarlark(libraryCtx LibraryExecutionContext, file *
 	}
 
 	l.ui.Debugf("## file %s\n", file.RelativePath())
+
+	fileBs = files.TrimUTF8BOM(fileBs)
 
 	instructions := template.NewInstructionSet()
 	compiledTemplate := template.NewCompiledTemplate(

--- a/pkg/yamlmeta/document_set.go
+++ b/pkg/yamlmeta/document_set.go
@@ -18,6 +18,11 @@ type DocSetOpts struct {
 func NewDocumentSetFromBytes(data []byte, opts DocSetOpts) (*DocumentSet, error) {
 	parserOpts := ParserOpts{WithoutComments: opts.WithoutComments, Strict: opts.Strict}
 
+	// Trimmed here as well as in ParseBytes so that the bytes retained below,
+	// which back AsSourceBytes and the source lines shown in template errors,
+	// are the same bytes that were parsed.
+	data = TrimUTF8BOM(data)
+
 	docSet, err := NewParser(parserOpts).ParseBytes(data, opts.AssociatedName)
 	if err != nil {
 		return nil, err

--- a/pkg/yamlmeta/document_set.go
+++ b/pkg/yamlmeta/document_set.go
@@ -6,6 +6,8 @@ package yamlmeta
 import (
 	"bytes"
 	"io"
+
+	"carvel.dev/ytt/pkg/files"
 )
 
 type DocSetOpts struct {
@@ -21,7 +23,7 @@ func NewDocumentSetFromBytes(data []byte, opts DocSetOpts) (*DocumentSet, error)
 	// Trimmed here as well as in ParseBytes so that the bytes retained below,
 	// which back AsSourceBytes and the source lines shown in template errors,
 	// are the same bytes that were parsed.
-	data = TrimUTF8BOM(data)
+	data = files.TrimUTF8BOM(data)
 
 	docSet, err := NewParser(parserOpts).ParseBytes(data, opts.AssociatedName)
 	if err != nil {

--- a/pkg/yamlmeta/parser.go
+++ b/pkg/yamlmeta/parser.go
@@ -39,8 +39,24 @@ func NewParser(opts ParserOpts) *Parser {
 	return &Parser{opts, ""}
 }
 
+// utf8BOM is the UTF-8 encoding of U+FEFF. Some editors, and Windows tooling in
+// particular, write it at the start of a file to record the encoding.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// TrimUTF8BOM returns data without a leading UTF-8 byte order mark. YAML treats
+// a BOM as a stream encoding marker rather than as content, so leaving it in
+// place makes it part of the first key.
+func TrimUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
+
 func (p *Parser) ParseBytes(data []byte, associatedName string) (*DocumentSet, error) {
 	p.associatedName = associatedName
+
+	// A BOM marks the encoding of the stream and is not content. It has to go
+	// before the document marker check below: a BOM in front of "---" hides the
+	// marker, so the parser prepends its own and the input stops parsing.
+	data = TrimUTF8BOM(data)
 
 	// YAML library uses 0-based line numbers for nodes (but, first line in a text file is typically line 1)
 	nodeLineCorrection := 1

--- a/pkg/yamlmeta/parser.go
+++ b/pkg/yamlmeta/parser.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"carvel.dev/ytt/pkg/filepos"
+	"carvel.dev/ytt/pkg/files"
 	"carvel.dev/ytt/pkg/yamlmeta/internal/yaml.v2"
 )
 
@@ -39,24 +40,13 @@ func NewParser(opts ParserOpts) *Parser {
 	return &Parser{opts, ""}
 }
 
-// utf8BOM is the UTF-8 encoding of U+FEFF. Some editors, and Windows tooling in
-// particular, write it at the start of a file to record the encoding.
-var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
-
-// TrimUTF8BOM returns data without a leading UTF-8 byte order mark. YAML treats
-// a BOM as a stream encoding marker rather than as content, so leaving it in
-// place makes it part of the first key.
-func TrimUTF8BOM(data []byte) []byte {
-	return bytes.TrimPrefix(data, utf8BOM)
-}
-
 func (p *Parser) ParseBytes(data []byte, associatedName string) (*DocumentSet, error) {
 	p.associatedName = associatedName
 
 	// A BOM marks the encoding of the stream and is not content. It has to go
 	// before the document marker check below: a BOM in front of "---" hides the
 	// marker, so the parser prepends its own and the input stops parsing.
-	data = TrimUTF8BOM(data)
+	data = files.TrimUTF8BOM(data)
 
 	// YAML library uses 0-based line numbers for nodes (but, first line in a text file is typically line 1)
 	nodeLineCorrection := 1

--- a/pkg/yamlmeta/parser_bom_test.go
+++ b/pkg/yamlmeta/parser_bom_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package yamlmeta_test
+
+import (
+	"testing"
+
+	"carvel.dev/ytt/pkg/yamlmeta"
+	"github.com/stretchr/testify/require"
+)
+
+const utf8BOM = "\xEF\xBB\xBF"
+
+func parseForBOMTest(t *testing.T, data string) *yamlmeta.DocumentSet {
+	t.Helper()
+
+	opts := yamlmeta.ParserOpts{WithoutComments: false}
+	docSet, err := yamlmeta.NewParser(opts).ParseBytes([]byte(data), "t.yml")
+	require.NoError(t, err)
+
+	return docSet
+}
+
+func printForBOMTest(docSet *yamlmeta.DocumentSet) string {
+	opts := yamlmeta.PrinterOpts{ExcludeRefs: true}
+	return yamlmeta.NewPrinterWithOpts(nil, opts).PrintStr(docSet)
+}
+
+// A UTF-8 BOM marks the encoding of a stream; it is not part of the first
+// key. Left in place it becomes a leading U+FEFF on that key, which then
+// renders as a quoted, escaped key in the output.
+func TestParserSkipsUTF8BOM(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "plain mapping", data: "test: null\n"},
+		{name: "document marker", data: "---\ntest: null\n"},
+		{name: "leading comment", data: "#! a comment\ntest: null\n"},
+		{name: "two documents", data: "test: null\n---\nsecond: null\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withBOM := parseForBOMTest(t, utf8BOM+tc.data)
+			withoutBOM := parseForBOMTest(t, tc.data)
+
+			require.Equal(t,
+				printForBOMTest(withoutBOM), printForBOMTest(withBOM),
+				"a leading UTF-8 BOM changed how the document parsed")
+		})
+	}
+}
+
+// The document marker check runs on the raw input, so a BOM in front of
+// "---" hides the marker. The parser then prepends its own marker, which
+// shifts reported positions and can make the input fail to parse at all.
+func TestParserPositionsAreCorrectAfterUTF8BOM(t *testing.T) {
+	const data = "---\ntest: null\n"
+
+	withBOM := parseForBOMTest(t, utf8BOM+data)
+	withoutBOM := parseForBOMTest(t, data)
+
+	require.Equal(t, len(withoutBOM.Items), len(withBOM.Items),
+		"a leading UTF-8 BOM changed the number of parsed documents")
+
+	wantPos := withoutBOM.Items[0].Position.AsIntString()
+	require.Equal(t, wantPos, withBOM.Items[0].Position.AsIntString(),
+		"a leading UTF-8 BOM shifted the reported line number")
+}


### PR DESCRIPTION
Fixes #999

## What

A file saved with a UTF-8 BOM was parsed with the BOM as content. In YAML it became a leading U+FEFF on the first key; in Starlark it caused a compile error; and in a text template it leaked into rendered output.

The YAML path also had a second failure: `ParseBytes` decides whether to prepend a document marker by matching `docStartMarkerCheck` against the raw input. A BOM in front of a leading `---` hid that marker, so the parser prepended a second one and the file did not parse.

## Where the fix lives, and why

The shared `files.TrimUTF8BOM` helper removes only a leading UTF-8 BOM. YAML parsing invokes it before the document-marker check. Starlark and text-template evaluation invoke it before compiling or parsing their template input.

The trim deliberately does not happen in `files.File.Bytes()`: that method also feeds the verbatim passthrough path, where a file force-marked `type=text` may be binary and must retain every byte. In `EvalText`, the trim therefore happens only after the plain/non-template passthrough returns.

`NewDocumentSetFromBytes` also trims so the bytes retained for `AsSourceBytes`—which back source lines shown in template errors—match the bytes parsed. The operation is idempotent. A U+FEFF later in a file remains ordinary content.

## Testing

- parser coverage compares BOM-prefixed YAML with the same input without a BOM across a plain mapping, explicit `---`, leading `#!` comment, and multi-document stream, including the hidden-marker failure
- end-to-end template coverage exercises the reported YAML case and confirms a mid-file BOM survives
- follow-through coverage confirms BOM-prefixed `.star` libraries and text templates behave exactly like their no-BOM equivalents

The new cases were confirmed failing before their respective implementation changes.

Fresh local validation on 18 Aug 2026:

- `go test ./... -count=1` — all packages pass, including `test/e2e` and `test/filetests` (with a locally built versioned `ytt` binary as required by the e2e harness)
- focused BOM tests and the affected package suites pass
- `git diff --check` passes; changed Go files are `gofmt` clean

The branch remains mergeable with current `develop` (`a3e1f7b`).

## AI assistance

This patch was prepared with AI assistance. The resulting diff and test output were reviewed locally before submission.
