### PR TITLE
Allow md5.sum() to run under strict FIPS 140-3 enforcement

### DIFF
--- a/pkg/yttlibrary/md5.go
+++ b/pkg/yttlibrary/md5.go
@@ -4,6 +4,7 @@
 package yttlibrary
 
 import (
+	"crypto/fips140"
 	"crypto/md5"
 	"fmt"
 
@@ -35,5 +36,16 @@ func (b md5Module) Sum(thread *starlark.Thread, f *starlark.Builtin, args starla
 		return starlark.None, err
 	}
 
-	return starlark.String(fmt.Sprintf("%x", md5.Sum([]byte(val)))), nil
+	// MD5 is not a FIPS 140-3 approved algorithm. This function is a general
+	// value-hashing convenience (e.g. for cache keys or dedup), not used for
+	// authentication or integrity verification, so it is safe to compute
+	// even under strict FIPS 140-3-only enforcement (GODEBUG=fips140=only).
+	// Without this, building with the native Go FIPS 140-3 module and
+	// running with fips140=only would panic on any call to md5.sum().
+	var sum [md5.Size]byte
+	fips140.WithoutEnforcement(func() {
+		sum = md5.Sum([]byte(val))
+	})
+
+	return starlark.String(fmt.Sprintf("%x", sum)), nil
 }


### PR DESCRIPTION
## Problem
`md5.sum()` (`pkg/yttlibrary/md5.go`) panics when ytt is built with the native Go FIPS 140-3 Cryptographic Module and run with `GODEBUG=fips140=only`: `crypto/md5`: use of MD5 is not allowed in FIPS 140-only mode
This happens because `crypto/md5.Sum()` unconditionally checks FIPS strict enforcement and panics if it's active, regardless of how the caller is using MD5.
Any user template calling `md5.sum()` will fail outright on a strict-FIPS build of ytt, even though this specific use of MD5 has nothing to do with security.

## Why this is safe to fix this way
`md5.sum()` in ytt is a general-purpose value-hashing convenience — e.g. generating cache keys or deduplication hashes from arbitrary Starlark values. It is never used for authentication, signing, or integrity verification. Go's `crypto/fips140` package exists specifically for this situation: it exposes `WithoutEnforcement`, a scoped escape hatch for call sites where FIPS-restricted algorithms are being used for a purpose that doesn't require FIPS compliance, without weakening enforcement for the rest of the binary.

## Fix
Wrap the `md5.Sum()` call in `crypto/fips140.WithoutEnforcement()` (requires Go >= 1.26, already satisfied by this module's `go.mod`). This exempts only this one call from strict enforcement — every other cryptographic operation in the binary (including `sha256.sum()`) remains under full FIPS 140-3 enforcement.
Outside of GODEBUG=fips140=only, WithoutEnforcement is a no-op passthrough, so this change has no effect on default or non-FIPS builds.

## Testing
- The existing filetests/ytt-library/md5.tpltest fixture, which previously panicked when built with GOFIPS140=v1.0.0 and run with GODEBUG=fips140=only, now passes.
- Ran the full test suite with and without strict FIPS mode (GODEBUG=fips140=only / GODEBUG=fips140=on / unset) — no new failures introduced in any mode, and md5.sum() output values are unchanged.
- Confirmed WithoutEnforcement's bypass and crypto/md5's panic check share the same underlying gate (GODEBUG fips140 == "only"), so this change is inert outside of strict FIPS mode by construction, not just by observation.


