### PR TITLE
Report an oversized expects= integer instead of panicking

### DIFF
--- a/pkg/cmd/template/cmd_overlays_test.go
+++ b/pkg/cmd/template/cmd_overlays_test.go
@@ -284,3 +284,30 @@ array:
 	assert.Equal(t, "tpl.yml", file.RelativePath())
 	assert.Equal(t, expectedYAMLTplData, string(file.Bytes()))
 }
+
+func TestDocumentOverlayExpectsOversizedIntegerDescriptiveError(t *testing.T) {
+	yamlTplData := []byte(`
+foo: 1
+`)
+
+	// an integer too large for int64 and for uint64 can never equal a node count,
+	// and it used to reach a panic instead of being reported
+	yamlOverlayTplData := []byte(`
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.all, expects=99999999999999999999999999999999999999999
+---
+foo: 2
+`)
+
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		files.MustNewFileFromSource(files.NewBytesSource("overlay.yml", yamlOverlayTplData)),
+	})
+
+	ui := ui.NewTTY(false)
+	opts := cmdtpl.NewOptions()
+
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	require.Error(t, out.Err)
+	assert.Contains(t, out.Err.Error(), "Expected 'expects' to be an integer that fits in 64 bits")
+}

--- a/pkg/yttlibrary/overlay/match_annotation_expects_kwarg.go
+++ b/pkg/yttlibrary/overlay/match_annotation_expects_kwarg.go
@@ -142,7 +142,11 @@ func (a MatchAnnotationExpectsKwarg) checkInt(typedVal starlark.Int, matches []*
 		return nil
 	}
 
-	panic("Unsure how to convert starlark.Int to int")
+	// the value is an integer, but too large for either int64 or uint64. It can
+	// never equal a node count, and it comes straight from the template, so report
+	// it rather than crashing ytt.
+	return fmt.Errorf("Expected '%s' to be an integer that fits in 64 bits, but was %s",
+		MatchAnnotationKwargExpects, typedVal.String())
 }
 
 func (a MatchAnnotationExpectsKwarg) checkString(typedVal starlark.String, matches []*filepos.Position) error {


### PR DESCRIPTION
`MatchAnnotationExpectsKwarg.checkInt` tries `Int64()` and then `Uint64()`, and panics if neither conversion succeeds:

```go
panic("Unsure how to convert starlark.Int to int")
```

That value comes straight out of the template, so an overlay like this crashes ytt:

```yaml
#@overlay/match by=overlay.all, expects=99999999999999999999999999999999999999999
```

```
panic: Unsure how to convert starlark.Int to int
overlay.MatchAnnotationExpectsKwarg.checkInt(...) match_annotation_expects_kwarg.go:145
```

A negative bignum does the same. An integer that fits in neither type can never equal a node count, so it is a bad input rather than an impossible state, and the other malformed `expects=` values are already reported as errors. This returns one in the same shape.

The test drives it through `RunWithFiles`, which is the path the CLI takes. It panics without the change.

Noted while verifying, not fixed here since it is a separate code path: `--data-value-yaml n=<bignum>` panics in `pkg/template/core/go_value.go` with a different message, so that one wants its own change.
