### PR TITLE
fix: Make rendering safe to use concurrently

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -8,7 +8,7 @@ if [ -z "$GITHUB_ACTION" ]; then
   go clean -testcache
 fi
 
-go test ./... "$@"
+go test -race ./... "$@"
 
 # run a "contract test" to smoke Go module integration
 (

--- a/pkg/cmd/template/cmd_concurrency_test.go
+++ b/pkg/cmd/template/cmd_concurrency_test.go
@@ -1,0 +1,122 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"sync"
+	"testing"
+
+	cmdtpl "carvel.dev/ytt/pkg/cmd/template"
+	"carvel.dev/ytt/pkg/cmd/ui"
+	"carvel.dev/ytt/pkg/files"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The library deliberately uses the Starlark features that depend on the
+// resolver flags this package enables (lambda, float, bitwise ops, recursion),
+// so that dropping any of those flags fails this test rather than passing
+// silently.
+var concurrencyLibData = []byte(`
+def factorial(n):
+  return 1 if n <= 1 else n * factorial(n - 1)
+end
+
+def build():
+  double = lambda x: x * 2
+  return {
+    "total": double(6),
+    "ratio": 1.5,
+    "masked": 12 & 10,
+    "shifted": 1 << 4,
+    "factorial": factorial(5),
+  }
+end
+`)
+
+var concurrencyTplData = []byte(`
+#@ load("lib.star", "build")
+#@ v = build()
+values:
+  total: #@ v["total"]
+  ratio: #@ v["ratio"]
+  masked: #@ v["masked"]
+  shifted: #@ v["shifted"]
+  factorial: #@ v["factorial"]
+`)
+
+const concurrencyExpected = `values:
+  total: 12
+  ratio: 1.5
+  masked: 8
+  shifted: 16
+  factorial: 120
+`
+
+// TestConcurrentRendersProduceIdenticalOutput renders the same input from many
+// goroutines at once. Embedders using ytt as a Go module render concurrently
+// (one render per request, or per reconcile loop), so RunWithFiles has to be
+// safe to call from multiple goroutines. Two pieces of package-level state used
+// to make it unsafe: the instruction set ID counter in pkg/template, and the
+// starlark-go resolver flags that were assigned on every compile.
+//
+// This should be run with -race to catch the races directly; the output
+// comparison catches the functional consequence of an ID collision between a
+// template and the library it loads.
+func TestConcurrentRendersProduceIdenticalOutput(t *testing.T) {
+	// A serial render first, so a failure in the concurrent phase is
+	// unambiguously about concurrency rather than about the template.
+	baseline, err := renderWithLib()
+	require.NoError(t, err)
+	require.Equal(t, concurrencyExpected, baseline)
+
+	const goroutines = 16
+
+	// Every goroutine gets its own output and error, so that we can report
+	// which one failed. Each one is separate so that we don't need to lock on
+	// anything
+	outs := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Go(func() {
+			outs[i], errs[i] = renderWithLib()
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent render %d failed", i)
+		assert.Equal(t, concurrencyExpected, outs[i],
+			"concurrent render %d diverged from the serial render", i)
+	}
+}
+
+// renderWithLib evaluates the template with the library available to load(),
+// returning the rendered YAML. Every call builds its own files and Options, as
+// each render is expected to do.
+func renderWithLib() (string, error) {
+	lib := files.NewBytesSource("lib.star", concurrencyLibData)
+	tpl := files.NewBytesSource("tpl.yaml", concurrencyTplData)
+
+	filesToProcess := []*files.File{
+		files.MustNewFileFromSource(lib),
+		files.MustNewFileFromSource(tpl),
+	}
+
+	out := cmdtpl.NewOptions().RunWithFiles(
+		cmdtpl.Input{Files: filesToProcess},
+		ui.NewTTY(false),
+	)
+	if out.Err != nil {
+		return "", out.Err
+	}
+
+	bs, err := out.DocSet.AsBytes()
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -15,8 +15,10 @@ import (
 	"github.com/k14s/starlark-go/syntax"
 )
 
-type EvaluationCtxDialectName string
-type EvaluationCtxDialects map[EvaluationCtxDialectName]EvaluationCtxDialect
+type (
+	EvaluationCtxDialectName string
+	EvaluationCtxDialects    map[EvaluationCtxDialectName]EvaluationCtxDialect
+)
 
 type CompiledTemplate struct {
 	name         string
@@ -28,13 +30,13 @@ type CompiledTemplate struct {
 	ctxs         []*EvaluationCtx
 }
 
-// NewCompiledTemplate creates a CompiledTemplate containing the generated code,
-// InstructionSet, and Nodes needed to template the resulting document.
-func NewCompiledTemplate(name string, code []Line,
-	instructions *InstructionSet, nodes *Nodes,
-	evalDialects EvaluationCtxDialects) *CompiledTemplate {
-
-	// TODO package globals
+// The Starlark templates used here require these resolver options. They live in
+// package-level variables in starlark-go, so they are set once here at init:
+// otherwise this causes a data race two templates compile concurrently, which
+// happens whenever ytt is embedded as a Go module and more than one render is
+// in flight. The values are process-wide by nature and never change, so this is
+// the best way to set it
+func init() {
 	resolve.AllowFloat = true
 	resolve.AllowSet = true
 	resolve.AllowLambda = true
@@ -42,7 +44,14 @@ func NewCompiledTemplate(name string, code []Line,
 	resolve.AllowBitwise = true
 	resolve.AllowRecursion = true
 	resolve.AllowGlobalReassign = true
+}
 
+// NewCompiledTemplate creates a CompiledTemplate containing the generated code,
+// InstructionSet, and Nodes needed to template the resulting document.
+func NewCompiledTemplate(name string, code []Line,
+	instructions *InstructionSet, nodes *Nodes,
+	evalDialects EvaluationCtxDialects,
+) *CompiledTemplate {
 	return &CompiledTemplate{
 		name:         name,
 		code:         code,
@@ -101,8 +110,8 @@ func (e *CompiledTemplate) DebugCodeAsString() string {
 // Eval templates a document by executing the compiled code and instructions from a CompiledTemplate.
 // `instructionBindings` maps the compiled code and instructions to functions defined on a CompiledTemplate.
 func (e *CompiledTemplate) Eval(thread *starlark.Thread, loader CompiledTemplateLoader) (
-	starlark.StringDict, interface{}, error) {
-
+	starlark.StringDict, interface{}, error,
+) {
 	globals := make(starlark.StringDict)
 
 	if e.nodes != nil {
@@ -137,8 +146,8 @@ func (e *CompiledTemplate) Eval(thread *starlark.Thread, loader CompiledTemplate
 
 func (e *CompiledTemplate) eval(
 	thread *starlark.Thread, globals starlark.StringDict) (
-	gs starlark.StringDict, resultVal interface{}, resultErr error) {
-
+	gs starlark.StringDict, resultVal interface{}, resultErr error,
+) {
 	// Catch any panics to give a better contextual information
 	defer func() {
 		if err := recover(); err != nil {
@@ -212,15 +221,15 @@ func (e *CompiledTemplate) newCtx(ctxType EvaluationCtxDialectName) *EvaluationC
 
 func (e *CompiledTemplate) tplSetCtxType(
 	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return starlark.None, nil
 }
 
 func (e *CompiledTemplate) tplStartCtx(
 	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	ctxType, err := tplcore.NewStarlarkValue(args.Index(0)).AsString()
 	if err != nil {
 		return starlark.None, err
@@ -237,8 +246,8 @@ func (e *CompiledTemplate) tplStartCtx(
 
 func (e *CompiledTemplate) tplEndCtx(
 	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	if len(e.ctxs) == 0 {
 		panic("unexpected ctx end")
 	}
@@ -259,42 +268,42 @@ func (e *CompiledTemplate) tplEndCtx(
 
 func (e *CompiledTemplate) tplSetNode(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplSetNode(thread, f, args, kwargs)
 }
 
 func (e *CompiledTemplate) tplSetMapItemKey(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplSetMapItemKey(thread, f, args, kwargs)
 }
 
 func (e *CompiledTemplate) tplStartNodeAnnotation(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplStartNodeAnnotation(thread, f, args, kwargs)
 }
 
 func (e *CompiledTemplate) tplCollectNodeAnnotation(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplCollectNodeAnnotation(thread, f, args, kwargs)
 }
 
 func (e *CompiledTemplate) tplStartNode(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplStartNode(thread, f, args, kwargs)
 }
 
 func (e *CompiledTemplate) TplReplaceNode(
 	thread *starlark.Thread, f *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-
+	args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
 	return e.ctxs[len(e.ctxs)-1].TplReplace(thread, f, args, kwargs)
 }

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -16,8 +16,11 @@ import (
 )
 
 type (
+	// EvaluationCtxDialectName is name of an evaluation dialect
 	EvaluationCtxDialectName string
-	EvaluationCtxDialects    map[EvaluationCtxDialectName]EvaluationCtxDialect
+	// EvaluationCtxDialects is a map of evaluation dialect names to their
+	// dialects
+	EvaluationCtxDialects map[EvaluationCtxDialectName]EvaluationCtxDialect
 )
 
 type CompiledTemplate struct {
@@ -110,7 +113,7 @@ func (e *CompiledTemplate) DebugCodeAsString() string {
 // Eval templates a document by executing the compiled code and instructions from a CompiledTemplate.
 // `instructionBindings` maps the compiled code and instructions to functions defined on a CompiledTemplate.
 func (e *CompiledTemplate) Eval(thread *starlark.Thread, loader CompiledTemplateLoader) (
-	starlark.StringDict, interface{}, error,
+	starlark.StringDict, any, error,
 ) {
 	globals := make(starlark.StringDict)
 
@@ -146,7 +149,7 @@ func (e *CompiledTemplate) Eval(thread *starlark.Thread, loader CompiledTemplate
 
 func (e *CompiledTemplate) eval(
 	thread *starlark.Thread, globals starlark.StringDict) (
-	gs starlark.StringDict, resultVal interface{}, resultErr error,
+	gs starlark.StringDict, resultVal any, resultErr error,
 ) {
 	// Catch any panics to give a better contextual information
 	defer func() {
@@ -215,20 +218,20 @@ func (e *CompiledTemplate) newCtx(ctxType EvaluationCtxDialectName) *EvaluationC
 		dialect:   e.evalDialects[ctxType],
 
 		pendingAnnotations: map[NodeTag]NodeAnnotations{},
-		pendingMapItemKeys: map[NodeTag]interface{}{},
+		pendingMapItemKeys: map[NodeTag]any{},
 	}
 }
 
 func (e *CompiledTemplate) tplSetCtxType(
-	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple,
+	_ *starlark.Thread, _ *starlark.Builtin,
+	_ starlark.Tuple, _ []starlark.Tuple,
 ) (starlark.Value, error) {
 	return starlark.None, nil
 }
 
 func (e *CompiledTemplate) tplStartCtx(
 	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple,
+	args starlark.Tuple, _ []starlark.Tuple,
 ) (starlark.Value, error) {
 	ctxType, err := tplcore.NewStarlarkValue(args.Index(0)).AsString()
 	if err != nil {
@@ -246,7 +249,7 @@ func (e *CompiledTemplate) tplStartCtx(
 
 func (e *CompiledTemplate) tplEndCtx(
 	thread *starlark.Thread, _ *starlark.Builtin,
-	args starlark.Tuple, kwargs []starlark.Tuple,
+	args starlark.Tuple, _ []starlark.Tuple,
 ) (starlark.Value, error) {
 	if len(e.ctxs) == 0 {
 		panic("unexpected ctx end")

--- a/pkg/template/instructions.go
+++ b/pkg/template/instructions.go
@@ -6,6 +6,7 @@ package template
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 )
 
 type InstructionSet struct {
@@ -20,13 +21,17 @@ type InstructionSet struct {
 	ReplaceNode           InstructionOp
 }
 
-var (
-	globalInsSetID = 1
-)
+// globalInsSetID names each InstructionSet apart from every other one, so that
+// the Starlark identifiers a template compiles down to cannot collide with
+// those of a template it loads.
+//
+// This is to protect concurrent usage when consumed as a Go module. In the
+// worse case scenario this could be a race that ends up with two templates
+// having the same ID.
+var globalInsSetID atomic.Int64
 
 func NewInstructionSet() *InstructionSet {
-	globalInsSetID++
-	uniqueID := globalInsSetID
+	uniqueID := globalInsSetID.Add(1)
 	return &InstructionSet{
 		SetCtxType:            InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_ctx_type", uniqueID)},
 		StartCtx:              InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_ctx", uniqueID)},

--- a/pkg/template/instructions_test.go
+++ b/pkg/template/instructions_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"sync"
+	"testing"
+
+	"carvel.dev/ytt/pkg/template"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewInstructionSetConcurrency tests that all identifiers NewInstructionSet
+// generates are unique when used concurrently.
+func TestNewInstructionSetConcurrency(t *testing.T) {
+	const (
+		goroutines     = 16
+		setsPerRoutine = 64
+		wantIDs        = goroutines * setsPerRoutine
+	)
+
+	// Each goroutine owns one slot, so collecting results needs no locking
+	// and cannot itself be a source of races.
+	generated := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Go(func() {
+			names := make([]string, setsPerRoutine)
+			for j := range names {
+				// Every identifier in a set derives from that set's ID, so one
+				// field is enough to spot a collision.
+				names[j] = template.NewInstructionSet().SetNode.Name
+			}
+			generated[i] = names
+		})
+	}
+	wg.Wait()
+
+	// Comparing counts rather than using require.Len keeps the failure
+	// message from dumping every generated identifier.
+	require.Equal(t, wantIDs, countUnique(generated),
+		"duplicate identifiers mean the ID counter lost updates")
+}
+
+func countUnique(groups [][]string) int {
+	unique := map[string]struct{}{}
+	for _, group := range groups {
+		for _, name := range group {
+			unique[name] = struct{}{}
+		}
+	}
+	return len(unique)
+}


### PR DESCRIPTION
I found out when I started using ytt as a library, rather than a CLI, that race tests were failing. I tracked it back down to ytt itself. There were two locations that were using global variables that weren't protected by some sort of syncronization. I made some small changes, along with some tests to check for it as well.