### PR TITLE
Create output files without execute permission

### DIFF
--- a/pkg/files/output_file.go
+++ b/pkg/files/output_file.go
@@ -8,6 +8,10 @@ import (
 	"path/filepath"
 )
 
+// outputFilePerm keeps generated files readable and writable by the owner
+// only, since they may contain sensitive data, without marking them executable.
+const outputFilePerm os.FileMode = 0600
+
 type OutputFile struct {
 	relativePath string
 	data         []byte
@@ -37,7 +41,8 @@ func (f OutputFile) Create(dirPath string) error {
 		return err
 	}
 
-	fd, err := os.OpenFile(resultPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0700)
+	fd, err := os.OpenFile(
+		resultPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, outputFilePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/files/output_file_test.go
+++ b/pkg/files/output_file_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package files_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"carvel.dev/ytt/pkg/files"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputFileCreatedWithoutExecutePermission(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+
+	out := files.NewOutputFile(
+		"config.yml", []byte("foo: bar\n"), files.TypeYAML)
+	err := out.Create(dir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, "config.yml"))
+	require.NoError(t, err)
+
+	require.Equal(t, "-rw-------", info.Mode().String())
+}


### PR DESCRIPTION
Fixes #302.

Output files written with `--output-files` were created with mode 0700, so they came out executable even though they never need to be. This creates them as 0600 instead, which matches the acceptance criteria on the issue: owner read/write only (they can contain sensitive data), no execute bit. Directories still use 0700 since they need the traverse bit.

Added a test that creates an output file and checks its permissions. It skips on Windows where the permission bits aren't meaningful.
