### PR TITLE
Detect self-referencing values instead of crashing with a stack overflow

### DIFF
--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -334,6 +334,66 @@ end`)
 	require.EqualError(t, out.Err, expectedErr)
 }
 
+func TestSelfReferencingValueReturnsError(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		tplData := []byte(`
+#@ def cyc():
+#@   x = []
+#@   x.append(x)
+#@   return x
+#@ end
+out: #@ cyc()`)
+
+		src := files.NewBytesSource("tpl.yml", tplData)
+		filesToProcess := []*files.File{files.MustNewFileFromSource(src)}
+
+		testUI := ui.NewTTY(false)
+		opts := cmdtpl.NewOptions()
+
+		out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, testUI)
+		require.Error(t, out.Err)
+		require.Contains(t, out.Err.Error(), "self-referencing list")
+	})
+	t.Run("dict", func(t *testing.T) {
+		tplData := []byte(`
+#@ def cyc():
+#@   x = {}
+#@   x["k"] = x
+#@   return x
+#@ end
+out: #@ cyc()`)
+
+		src := files.NewBytesSource("tpl.yml", tplData)
+		filesToProcess := []*files.File{files.MustNewFileFromSource(src)}
+
+		testUI := ui.NewTTY(false)
+		opts := cmdtpl.NewOptions()
+
+		out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, testUI)
+		require.Error(t, out.Err)
+		require.Contains(t, out.Err.Error(), "self-referencing dict")
+	})
+	t.Run("indirect list-dict cycle", func(t *testing.T) {
+		tplData := []byte(`
+#@ def cyc():
+#@   x = []
+#@   x.append({"k": x})
+#@   return x
+#@ end
+out: #@ cyc()`)
+
+		src := files.NewBytesSource("tpl.yml", tplData)
+		filesToProcess := []*files.File{files.MustNewFileFromSource(src)}
+
+		testUI := ui.NewTTY(false)
+		opts := cmdtpl.NewOptions()
+
+		out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, testUI)
+		require.Error(t, out.Err)
+		require.Contains(t, out.Err.Error(), "self-referencing list")
+	})
+}
+
 func TestDisallowDirectLibraryLoading(t *testing.T) {
 	yamlTplData := []byte(`#@ load("_ytt_lib/data.lib.star", "data")`)
 

--- a/pkg/template/core/starlark_value.go
+++ b/pkg/template/core/starlark_value.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 
 	"carvel.dev/ytt/pkg/orderedmap"
@@ -29,7 +30,7 @@ func NewStarlarkValue(val starlark.Value) StarlarkValue {
 }
 
 func (e StarlarkValue) AsGoValue() (interface{}, error) {
-	return e.asInterface(e.val)
+	return e.asInterface(e.val, nil)
 }
 
 func (e StarlarkValue) AsString() (string, error) {
@@ -68,69 +69,90 @@ func (e StarlarkValue) AsFloat64() (float64, error) {
 	return 0, fmt.Errorf("expected float value, but was %T", e.val)
 }
 
-func (e StarlarkValue) asInterface(val starlark.Value) (interface{}, error) {
+// path holds the *starlark.Dict and *starlark.List values currently being
+// converted, so that a value that (directly or indirectly) contains itself
+// is reported as an error instead of recursing until the stack overflows.
+// Dict and List are the only Starlark values that can be mutated after
+// creation, so they are the only ones that can participate in a cycle.
+func (e StarlarkValue) asInterface(
+	val starlark.Value, path []starlark.Value,
+) (any, error) {
 	if obj, ok := val.(UnconvertableStarlarkValue); ok {
 		return nil, fmt.Errorf("Unable to convert value: %s", obj.ConversionHint())
 	}
 	if obj, ok := val.(StarlarkValueToGoValueConversion); ok {
 		return obj.AsGoValue()
 	}
+	if result, handled, err := scalarAsInterface(val); handled {
+		return result, err
+	}
 
 	switch typedVal := val.(type) {
-	case nil, starlark.NoneType:
-		return nil, nil // TODO is it nil or is it None
-
-	case starlark.Bool:
-		return bool(typedVal), nil
-
-	case starlark.String:
-		return string(typedVal), nil
-
-	case starlark.Int:
-		i1, ok := typedVal.Int64()
-		if ok {
-			return i1, nil
-		}
-		i2, ok := typedVal.Uint64()
-		if ok {
-			return i2, nil
-		}
-		panic("not sure how to get int") // TODO
-
-	case starlark.Float:
-		return float64(typedVal), nil
-
 	case *starlark.Dict:
-		return e.dictAsInterface(typedVal)
+		return e.dictAsInterface(typedVal, path)
 
 	case *StarlarkStruct:
-		return e.structAsInterface(typedVal)
+		return e.structAsInterface(typedVal, path)
 
 	case *starlark.List:
-		return e.itearableAsInterface(typedVal)
+		return e.itearableAsInterface(typedVal, path)
 
 	case starlark.Tuple:
-		return e.itearableAsInterface(typedVal)
+		return e.itearableAsInterface(typedVal, path)
 
 	case *starlark.Set:
-		return e.itearableAsInterface(typedVal)
+		return e.itearableAsInterface(typedVal, path)
 
 	default:
 		panic(fmt.Sprintf("unknown type %T for conversion to go value", val))
 	}
 }
 
-func (e StarlarkValue) dictAsInterface(val *starlark.Dict) (interface{}, error) {
+// scalarAsInterface converts a scalar Starlark value to its Go equivalent.
+// handled is false if val is not one of the types this function handles.
+func scalarAsInterface(
+	val starlark.Value,
+) (result any, handled bool, err error) {
+	switch typedVal := val.(type) {
+	case nil, starlark.NoneType:
+		return nil, true, nil // TODO is it nil or is it None
+
+	case starlark.Bool:
+		return bool(typedVal), true, nil
+
+	case starlark.String:
+		return string(typedVal), true, nil
+
+	case starlark.Int:
+		i1, ok := typedVal.Int64()
+		if ok {
+			return i1, true, nil
+		}
+		i2, ok := typedVal.Uint64()
+		if ok {
+			return i2, true, nil
+		}
+		panic("not sure how to get int") // TODO
+
+	case starlark.Float:
+		return float64(typedVal), true, nil
+
+	default:
+		return nil, false, nil
+	}
+}
+
+func (e StarlarkValue) dictAsInterface(
+	val *starlark.Dict, path []starlark.Value,
+) (any, error) {
+	if pathContains(path, val) {
+		return nil, errors.New("Unable to convert value: self-referencing dict")
+	}
+	path = append(path, val)
+
 	result := orderedmap.NewMap()
 	for _, item := range val.Items() {
-		if item.Len() != 2 {
-			panic("dict item is not KV")
-		}
-		key, err := e.asInterface(item.Index(0))
-		if err != nil {
-			return nil, err
-		}
-		value, err := e.asInterface(item.Index(1))
+		key, value, err := e.dictItemAsInterface(item, path)
 		if err != nil {
 			return nil, err
 		}
@@ -139,11 +161,34 @@ func (e StarlarkValue) dictAsInterface(val *starlark.Dict) (interface{}, error) 
 	return result, nil
 }
 
-func (e StarlarkValue) structAsInterface(val *StarlarkStruct) (interface{}, error) {
+// dictItemKeyValueLen is the length of a starlark.Tuple representing a
+// single dict item: exactly one key and one value.
+const dictItemKeyValueLen = 2
+
+func (e StarlarkValue) dictItemAsInterface(
+	item starlark.Tuple, path []starlark.Value,
+) (key, value any, err error) {
+	if item.Len() != dictItemKeyValueLen {
+		panic("dict item is not KV")
+	}
+	key, err = e.asInterface(item.Index(0), path)
+	if err != nil {
+		return nil, nil, err
+	}
+	value, err = e.asInterface(item.Index(1), path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, value, nil
+}
+
+func (e StarlarkValue) structAsInterface(
+	val *StarlarkStruct, path []starlark.Value,
+) (any, error) {
 	// TODO accessing privates
 	result := orderedmap.NewMap()
 	err := val.data.IterateErr(func(k, v interface{}) error {
-		value, err := e.asInterface(v.(starlark.Value))
+		value, err := e.asInterface(v.(starlark.Value), path)
 		if err == nil {
 			result.Set(k, value)
 		}
@@ -155,18 +200,54 @@ func (e StarlarkValue) structAsInterface(val *StarlarkStruct) (interface{}, erro
 	return result, nil
 }
 
-func (e StarlarkValue) itearableAsInterface(iterable starlark.Iterable) (interface{}, error) {
+func (e StarlarkValue) itearableAsInterface(
+	iterable starlark.Iterable, path []starlark.Value,
+) (any, error) {
+	path, err := extendPathWithList(path, iterable)
+	if err != nil {
+		return nil, err
+	}
+
 	iter := iterable.Iterate()
 	defer iter.Done()
 
 	var result []interface{}
 	var x starlark.Value
 	for iter.Next(&x) {
-		elem, err := e.asInterface(x)
+		elem, err := e.asInterface(x, path)
 		if err != nil {
 			return nil, err
 		}
 		result = append(result, elem)
 	}
 	return result, nil
+}
+
+// extendPathWithList appends list to path, erroring out if it is already
+// present (i.e. list directly or indirectly contains itself). Non-list
+// iterables are returned unchanged, since only *starlark.List and
+// *starlark.Dict are mutable enough to form a cycle.
+func extendPathWithList(
+	path []starlark.Value, iterable starlark.Iterable,
+) ([]starlark.Value, error) {
+	list, ok := iterable.(*starlark.List)
+	if !ok {
+		return path, nil
+	}
+	if pathContains(path, list) {
+		return nil, errors.New("Unable to convert value: self-referencing list")
+	}
+	return append(path, list), nil
+}
+
+// pathContains reports whether x is already present in path.
+// Every value ever added to path is a *starlark.Dict or *starlark.List,
+// both of which are comparable, so this equality check is safe.
+func pathContains(path []starlark.Value, x starlark.Value) bool {
+	for _, y := range path {
+		if x == y {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Motivation:
A Starlark list or dict that (directly or indirectly) contains itself
made ytt's Starlark-to-Go value conversion recurse forever, aborting
the process with an unrecoverable Go runtime "fatal error: stack
overflow" after allocating up to 1GB of stack. This has no ytt-level
error message and exit code 2, and because it is a Go runtime fatal
error (not a panic), it cannot be recovered by an embedding program
using ytt as a library. This affects YAML/text template rendering as
well as @ytt:json's json.encode() and @ytt:yaml's yaml.encode(), all
of which route through the same conversion path.

Approach:
pkg/template/core/starlark_value.go's asInterface/dictAsInterface/
itearableAsInterface now thread a path argument through the recursive
conversion, recording the *starlark.Dict and *starlark.List values
currently being converted (i.e. the ancestors in the current
recursion). Encountering a dict or list already present in path now
returns a normal ytt error instead of recursing further. Only Dict
and List are checked: starlark.Tuple is immutable after construction,
*starlark.Set can only hold hashable elements so it can never hold a
Dict/List/itself, and ytt's own *StarlarkStruct is built once from a
fixed map with no field-mutation exposed to Starlark code, so none of
those three can participate in a cycle. This mirrors the cycle
detection already used by the vendored starlark-go library itself in
starlark/value.go's writeValue/pathContains (used by str() on
Starlark values), which uses the same append(path, x) idiom and also
only checks List and Dict.

The remainder of the diff (extracting scalarAsInterface,
dictItemAsInterface, and extendPathWithList, wrapping long function
signatures, and a dictItemKeyValueLen constant) is a mechanical,
behavior-preserving split of the existing type switch, needed to stay
under this repo's golangci-lint (revive, enable-all-rules) complexity
and line-length limits once the path parameter touched those lines.

Validation:
- go build ./... succeeds.
- go test ./... passes for the whole repo, including a new test,
  TestSelfReferencingValueReturnsError in
  pkg/cmd/template/cmd_test.go, covering a direct self-referencing
  list, a direct self-referencing dict, and an indirect list->dict->
  list cycle, using the exact repro from the issue. Confirmed this
  test fails before the fix: with only the fix reverted (via git
  stash on starlark_value.go), the list subtest reproduces the actual
  "fatal error: stack overflow" crash from the issue; restoring the
  fix makes all subtests pass.
- golangci-lint run ./... (v2.12.2, matching the version pinned in
  .github/workflows/golangci-lint.yml) reports 0 issues.
- Manually ran the built ytt binary against the issue's exact repro
  (self-referencing list and dict), against @ytt:json's json.encode()
  on a self-referencing list, and against a non-cyclic case where the
  same dict value is legitimately shared by reference at multiple
  points in the output, to confirm sharing (as opposed to a cycle) is
  still converted correctly and not falsely flagged.

Report: https://github.com/carvel-dev/ytt/issues/1006
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1006