### PR TITLE
Report each builtin's own name when it errors

### DIFF
--- a/pkg/yamltemplate/filetests/ytt-library/math-mod-err.tpltest
+++ b/pkg/yamltemplate/filetests/ytt-library/math-mod-err.tpltest
@@ -1,0 +1,10 @@
+#@ load("@ytt:math", "math")
+
+val: #@ math.mod(5)
+
++++
+
+ERR: 
+- mod: expected exactly two arguments
+    in <toplevel>
+      stdin:3 | val: #@ math.mod(5)

--- a/pkg/yamltemplate/filetests/ytt-library/overlay/not-op-err.tpltest
+++ b/pkg/yamltemplate/filetests/ytt-library/overlay/not-op-err.tpltest
@@ -1,0 +1,24 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@ def matcher(idx, left, right):
+#@   return "yes"
+#@ end
+
+#@ def test_left():
+- name: first
+#@ end
+
+#@ def test_right():
+#@overlay/match by=overlay.not_op(matcher)
+- name: second
+#@ end
+
+---
+test: #@ overlay.apply(test_left(), test_right())
+
++++
+
+ERR: 
+- overlay.apply: Array item on line stdin:13: overlay.not_op: expected starlark.Bool, but was starlark.String
+    in <toplevel>
+      stdin:17 | test: #@ overlay.apply(test_left(), test_right())

--- a/pkg/yttlibrary/math.go
+++ b/pkg/yttlibrary/math.go
@@ -115,7 +115,7 @@ func (m MathModule) AsModule() starlark.StringDict {
 				"copysign":  m.newBinaryBuiltin("copysign", math.Copysign),
 				"fabs":      m.newUnaryBuiltin("fabs", math.Abs),
 				"floor":     starlark.NewBuiltin("floor", m.warnOnCall(core.ErrWrapper(m.floor))),
-				"mod":       m.newBinaryBuiltin("round", math.Mod),
+				"mod":       m.newBinaryBuiltin("mod", math.Mod),
 				"pow":       m.newBinaryBuiltin("pow", math.Pow),
 				"remainder": m.newBinaryBuiltin("remainder", math.Remainder),
 				"round":     m.newUnaryBuiltin("round", math.Round),

--- a/pkg/yttlibrary/overlay/api.go
+++ b/pkg/yttlibrary/overlay/api.go
@@ -320,5 +320,5 @@ func (b overlayModule) NotOp(
 		return starlark.Bool(!resultBool), nil
 	}
 
-	return starlark.NewBuiltin("overlay.or_op", core.ErrWrapper(matchFunc)), nil
+	return starlark.NewBuiltin("overlay.not_op", core.ErrWrapper(matchFunc)), nil
 }


### PR DESCRIPTION
## Summary

Two builtins in the standard library are registered under a different function's name, so when one of them fails, ytt names a function the user never called.

`pkg/yttlibrary/math.go:118` registers the `mod` member as `m.newBinaryBuiltin("round", math.Mod)`. `core.ErrWrapper` prefixes every error with `f.Name()` (`pkg/template/core/errs.go:30`), so `math.mod(5)` fails with `round: expected exactly two arguments`. `math.round` is a real function in the same module, so the message points at the wrong call.

`pkg/yttlibrary/overlay/api.go:323` returns the matcher built by `overlay.not_op` as `starlark.NewBuiltin("overlay.or_op", ...)`, copied from `OrOp` directly above it. An error raised while matching under `@overlay/match by=overlay.not_op(...)` comes back as `overlay.or_op`.

Each builtin now carries its own name. Nothing else changes: `mod` still calls `math.Mod` and `not_op` still negates its matcher.

I checked every other `starlark.NewBuiltin` call under `pkg/` for the same slip. These two are the only ones that name a different function.

## Testing

One filetest per module, both asserting the error text:

* `pkg/yamltemplate/filetests/ytt-library/math-mod-err.tpltest`
* `pkg/yamltemplate/filetests/ytt-library/overlay/not-op-err.tpltest`

With the two source changes reverted and the new tests kept, `go test -count=1 ./pkg/yamltemplate/...` fails on both, showing the old names:

```
--- FAIL: TestYAMLTemplate/filetests/ytt-library/math-mod-err.tpltest
        result:   - round: expected exactly two arguments
        expected: - mod: expected exactly two arguments
--- FAIL: TestYAMLTemplate/filetests/ytt-library/overlay/not-op-err.tpltest
        result:   - overlay.apply: Array item on line stdin:13: overlay.or_op: expected starlark.Bool, but was starlark.String
        expected: - overlay.apply: Array item on line stdin:13: overlay.not_op: expected starlark.Bool, but was starlark.String
```

Local runs on macOS arm64 with Go 1.26.4, on 7 Sep 2026:

* `go test -count=1 ./...` passes, `test/e2e` and `test/filetests` included, against a `ytt` binary built from this branch
* `gofmt -l pkg/yttlibrary/math.go pkg/yttlibrary/overlay/api.go` prints nothing
* `git diff --check` is clean

Branched from `develop` at `6a94bf4`.
